### PR TITLE
Fix download size limit

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ async function uploadDockerImage(thisOwner, thisRepo, packageName) {
                         await streamPipeline(downloadResponse.body, fs.createWriteStream(package.name + '.zip'));
 
                         console.log('Unzipping');
-                        await exec('unzip -o ' + package.name + '.zip');
+                        await exec('unzip -o ' + package.name + '.zip && rm -f ' + package.name + '.zip');
 
                         console.log('Confirming sha256');
                         const {stdout} = await exec('sha256sum ' + package.name);

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ async function uploadDockerImage(thisOwner, thisRepo, packageName) {
     await exec('grep "Loaded image" docker_load_output | cut -d" " -f 3 > loaded_repotag');
 
     // Artifact name needs to match naming convention. Otherwise we'd have to download artifacts to get the tag to tell if they'd already been uploaded as packages.
-    await exec('echo Confirming repo/tag in file $(cat loaded_repotag) consistent with repo/tag guessed from filename ' + repoTagGuessedFromFileName + ' && [ "$(cat loaded_repotag | cut -d/ -f 2)" = "' + repoTagGuessedFromFileName + '" ]');
+    await exec('echo Confirming repo/tag in file $(cat loaded_repotag) consistent with repo/tag guessed from filename ' + repoTagGuessedFromFileName + ' && [ "$(cat loaded_repotag | rev | cut -d/ -f 1 | rev)" = "' + repoTagGuessedFromFileName + '" ]');
 
     const newTag = (dockerHost + '/' + thisOwner + '/' + thisRepo + '/' + repoTagGuessedFromFileName).toLowerCase();
 


### PR DESCRIPTION
This PR fixes the download size limit of 2GB for artifacts to be republished. Tested locally with nodejs and on a [forked repo with GitHub Actions](https://github.com/jgiannuzzi/check-and-republish-packages/runs/7279680185?check_suite_focus=true#step:2:21).